### PR TITLE
Quoting fixes

### DIFF
--- a/crates/kak/src/init.kak
+++ b/crates/kak/src/init.kak
@@ -9,10 +9,8 @@ declare-option str skyspell_word_to_add
 set-face global SpellingError ,,red+c
 
 define-command -params 1 skyspell-enable %{
-  evaluate-commands %sh{
-    echo "set global skyspell_lang $1"
-    echo "set global skyspell_project $(pwd)"
-  }
+  set global skyspell_lang %arg{1}
+  set global skyspell_project %sh{pwd}
   add-highlighter global/spell ranges skyspell_errors
   hook -group skyspell global BufWritePost .* skyspell-check
   hook -group skyspell global BufCreate \*spelling\* skyspell-hooks

--- a/crates/kak/src/init.kak
+++ b/crates/kak/src/init.kak
@@ -47,7 +47,8 @@ define-command skyspell-check -docstring "check the open buffers for spelling er
   evaluate-commands %sh{
     : $kak_timestamp
     : $kak_opt_skyspell_project
-    skyspell-kak --lang $kak_opt_skyspell_lang check $kak_quoted_buflist
+    eval set -- "$kak_quoted_buflist"
+    skyspell-kak --lang $kak_opt_skyspell_lang check "$@"
     if [ $? -ne 0 ]; then
       echo skyspell-kak-on-failure
     fi


### PR DESCRIPTION
These should fix #7.

Remark:

Instead of 
```
eval set -- "$kak_quoted_buflist"
skyspell-kak --lang $kak_opt_skyspell_lang check "$@"
```
the oneline
```
eval skyspell-kak --lang $kak_opt_skyspell_lang check "kak_quoted_buflist"
```
would also work.

However:
* Using `set` indicates to me some kind of quoting might be in play
* `$kak_opt_skypsell_lang` is evaluated twice: once for interpolation and the second time with eval.  For a fixed letter-only string like `en` this is not a problem, but it becomes one if the user sets it to `$(rm -rf /)".